### PR TITLE
Handle unicode characters in package metadata

### DIFF
--- a/req_compile/metadata/extractor.py
+++ b/req_compile/metadata/extractor.py
@@ -93,7 +93,7 @@ class Extractor(metaclass=abc.ABCMeta):
         if "b" in mode:
             return handle
 
-        return cast(IO[str], WithDecoding(handle, encoding or "ascii", errors, newline))
+        return cast(IO[str], WithDecoding(handle, encoding or "utf-8", errors, newline))
 
     @abc.abstractmethod
     def names(self) -> Iterable[str]:

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -76,6 +76,16 @@ def test_wrapped_encoding(mock_targz, tmp_path):
             assert isinstance(utf8_file.read(1), str)
 
 
+def test_default_encoding_handles_non_ascii(mock_targz, tmp_path):
+    archive: TarExtractor = TarExtractor("gz", mock_targz("tar-utf8-1.1.0"))
+    root = str(tmp_path)
+    archive.fake_root = root
+    with temp_cwd(root):
+        with archive.open("tar-utf8-1.1.0/setup.py", "r") as f:
+            contents = f.read()
+        assert "Puré" in contents
+
+
 def test_pathlib_open_with_encoding(monkeypatch, mock_targz, tmp_path):
     directory = "comtypes-1.1.7"
     archive: TarExtractor = TarExtractor("gz", mock_targz(directory))


### PR DESCRIPTION
This change fixes `bad metadata` errors. A repro is to apply the following diff:
```diff
diff --git a/private/examples/multiplatform_py_test/requirements.in b/private/examples/multiplatform_py_test/requirements.in
index 7e10602..e49511c 100644
--- a/private/examples/multiplatform_py_test/requirements.in
+++ b/private/examples/multiplatform_py_test/requirements.in
@@ -1 +1,2 @@
 flask
+hexdump
```
And then run the compiler target in the `private/examples/multiplatform_py_test` directory
```
multiplatform_py_test % bazel run :requirements_update.macos
```
```
WARNING: For repository 'rules_python', the root module requires module version rules_python@1.3.0, but got rules_python@1.7.0 in the resolved dependency graph.
WARNING: For repository 'platforms', the root module requires module version platforms@0.0.11, but got platforms@1.0.0 in the resolved dependency graph.
INFO: Analyzed target //:requirements_update.macos (109 packages loaded, 4331 targets configured).
INFO: Found 1 target...
Target //:requirements_update.macos up-to-date:
  bazel-bin/requirements_update.macos.compiler_bin
INFO: Elapsed time: 8.190s, Critical Path: 0.52s
INFO: 14 processes: 14 internal.
INFO: Build completed successfully, 14 total actions
INFO: Running command line: bazel-bin/requirements_update.macos.compiler_bin
No working candidates found for hexdump. Required by:
  _main/requirements.in -> hexdump
Found the following candidates, none of which will work:
  --solution /Users/user/Code/req-compile/private/examples/multiplatform_py_test/requirements.macos.txt:
  No candidates found
  <default index> https://pypi.org/simple:
  SDIST hexdump-3.3-none-none-any: unknown (CantUseReason.U_CAN_USE)
  SDIST hexdump-3.2-none-none-any: unknown (CantUseReason.U_CAN_USE)
  SDIST hexdump-3.1-none-none-any: unknown (CantUseReason.U_CAN_USE)
WARNING:req_compile.metadata.source:Failed to parse hexdump
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/private/compiler.py", line 249, in compile_requirements
    compiled_solution, dep_nodes = perform_compile(
                                   ^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/compile.py", line 382, in perform_compile
    compile_roots(
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/compile.py", line 292, in compile_roots
    compile_roots(
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/compile.py", line 243, in compile_roots
    metadata, cached = repo.get_dist(
                       ^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/repos/multi.py", line 47, in get_dist
    raise last_ex
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/repos/multi.py", line 40, in get_dist
    return repo.get_dist(
           ^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/repos/repository.py", line 662, in get_dist
    return self.do_get_candidate(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/repos/repository.py", line 751, in do_get_candidate
    raise NoCandidateException(req)
req_compile.errors.NoCandidateException: NoCandidateException - no candidates found for "hexdump"

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/private/compiler.py", line 399, in compile_main
    result = compile_requirements(
             ^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/private/compiler.py", line 256, in compile_requirements
    raise CompilationError(repo=repo, parent=exc) from exc
CompilationError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/metadata/source.py", line 228, in _fetch_from_setup_py
    results = _parse_setup_py(name, setup_file, extractor)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/metadata/source.py", line 862, in _parse_setup_py
    exec(contents, spy_globals, spy_globals)
  File "<string>", line 53, in <module>
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/metadata/extractor.py", line 292, in read
    return self.reader.read(__n)
           ^^^^^^^^^^^^^^^^^^^^^
  File "<frozen codecs>", line 507, in read
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 1856: ordinal not in range(128)
  SDIST hexdump-3.0-none-none-any: unknown (CantUseReason.U_CAN_USE)
  SDIST hexdump-2.0-none-none-any: unknown (CantUseReason.U_CAN_USE)
  SDIST hexdump-1.0-none-none-any: unknown (CantUseReason.U_CAN_USE)
  SDIST hexdump-0.5-none-none-any: unknown (CantUseReason.U_CAN_USE)
  SDIST hexdump-0.4-none-none-any: unknown (CantUseReason.U_CAN_USE)
WARNING:req_compile.metadata.source:Failed to parse hexdump
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/private/compiler.py", line 249, in compile_requirements
    compiled_solution, dep_nodes = perform_compile(
                                   ^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/compile.py", line 382, in perform_compile
    compile_roots(
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/compile.py", line 292, in compile_roots
    compile_roots(
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/compile.py", line 243, in compile_roots
    metadata, cached = repo.get_dist(
                       ^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/repos/multi.py", line 47, in get_dist
    raise last_ex
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/repos/multi.py", line 40, in get_dist
    return repo.get_dist(
           ^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/repos/repository.py", line 662, in get_dist
    return self.do_get_candidate(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/repos/repository.py", line 751, in do_get_candidate
    raise NoCandidateException(req)
req_compile.errors.NoCandidateException: NoCandidateException - no candidates found for "hexdump"

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/private/compiler.py", line 399, in compile_main
    result = compile_requirements(
             ^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/private/compiler.py", line 256, in compile_requirements
    raise CompilationError(repo=repo, parent=exc) from exc
CompilationError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/metadata/source.py", line 228, in _fetch_from_setup_py
    results = _parse_setup_py(name, setup_file, extractor)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_req_compile~/req_compile/metadata/source.py", line 862, in _parse_setup_py
    exec(contents, spy_globals, spy_globals)
  File "<string>", line 17, in <module>
  File "<string>", line 7, in get_version
  File "<frozen codecs>", line 648, in __next__
  File "<frozen codecs>", line 561, in readline
  File "<frozen codecs>", line 507, in read
UnicodeDecodeError: 'ascii' codec can't decode byte 0xa6 in position 0: ordinal not in range(128)
WARNING:req_compile.metadata.source:Failed to build egg-info for hexdump:
The command "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_python~~python~python_3_11_aarch64-apple-darwin/bin/python3 -c "import setuptools, tokenize;__file__='/var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/tmp3u08j0_y/hexdump-0.3/setup.py';f = getattr(tokenize, 'open', open)(__file__);code = f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" egg_info --egg-base /var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/tmp3u08j0_y/hexdump-0.3" produced:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/tmp3u08j0_y/hexdump-0.3/setup.py", line 17, in <module>
    version=get_version('hexdump.py'),
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/tmp3u08j0_y/hexdump-0.3/setup.py", line 7, in get_version
    for line in open(join(dirname(__file__), relpath)):
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa6 in position 479: invalid start byte

WARNING:req_compile.metadata.source:Failed to build wheel for hexdump:
The command "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_python~~python~python_3_11_aarch64-apple-darwin/bin/python3 -m pip wheel /var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/tmp3u08j0_y/hexdump-0.3 --no-deps --wheel-dir /var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/tmpo6swsgac" produced:
Processing /var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/tmp3u08j0_y/hexdump-0.3
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error

   Getting requirements to build wheel did not run successfully.
   exit code: 1
  > [22 lines of output]
      Traceback (most recent call last):
        File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/external/rules_python~~python~python_3_11_aarch64-apple-darwin/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/external/rules_python~~python~python_3_11_aarch64-apple-darwin/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/external/rules_python~~python~python_3_11_aarch64-apple-darwin/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/pip-build-env-59gzdmzl/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/pip-build-env-59gzdmzl/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/pip-build-env-59gzdmzl/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 520, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/private/var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/pip-build-env-59gzdmzl/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 17, in <module>
        File "<string>", line 7, in get_version
        File "<frozen codecs>", line 322, in decode
      UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa6 in position 479: invalid start byte
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.

[notice] A new release of pip is available: 25.2 -> 26.1.1
[notice] To update, run: /private/var/tmp/_bazel_user/c60e534beb6a7a5c7bfa5c14a3d02e3a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/requirements_update.macos.compiler_bin.runfiles/rules_python~~python~python_3_11_aarch64-apple-darwin/bin/python3 -m pip install --upgrade pip
error: subprocess-exited-with-error

 Getting requirements to build wheel did not run successfully.
 exit code: 1
> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

WARNING:req_compile.metadata.source:No metadata source could be found for the source dist /var/folders/h4/_xm41cq11v90znmm9dz87wdc0000gn/T/tmp2w8dimp1/hexdump-0.3.zip
  SDIST hexdump-0.3-none-none-any: bad metadata
```